### PR TITLE
tweak(chargepistols): removes lack of ability to stick chargepistols and their ammo into security belts

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -171,6 +171,7 @@
 		/obj/item/device/megaphone,
 		/obj/item/melee,
 		/obj/item/gun/projectile/pistol/vp78,
+		/obj/item/gun/charge/pistol,
 		/obj/item/taperoll,
 		/obj/item/device/holowarrant,
 		/obj/item/rcd_ammo/magnetic_ammo,

--- a/code/modules/clothing/under/accessories/storage.dm
+++ b/code/modules/clothing/under/accessories/storage.dm
@@ -164,6 +164,7 @@
 		/obj/item/device/multitool,
 		/obj/item/rcd_ammo/magnetic_ammo,
 		/obj/item/ammo_magazine,
+		/obj/item/cell/ammo/charge,
 		/obj/item/net_shell,
 		/obj/item/reagent_containers/vessel/beaker/vial,
 		/obj/item/ammo_casing/grenade


### PR DESCRIPTION

Теперь можно засовывать чарджпистолеты в офицерские пояса, а магазины помимо поясов и в бандольеры. 

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Чарджпистолеты теперь влезают в офицерские пояса, а их магазины - в бандольеры.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
